### PR TITLE
add workflow for publish npmjs

### DIFF
--- a/.github/workflows/publish_npmjs.yml
+++ b/.github/workflows/publish_npmjs.yml
@@ -1,0 +1,18 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [created]
+  workflow_dispatch: 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
初回は手動で実行するのでworkflow_dispatchを追加
参考
https://docs.github.com/ja/actions/publishing-packages/publishing-nodejs-packages