### PR TITLE
add ABHubBuildParameters

### DIFF
--- a/Editor/BuildPipeline.cs
+++ b/Editor/BuildPipeline.cs
@@ -9,6 +9,7 @@ using UnityEditor.Build.Pipeline;
 using UnityEditor.Build.Pipeline.Interfaces;
 using AssetBundleHub;
 using AssetBundleHubEditor.Tasks;
+using AssetBundleHubEditor.Interfaces;
 
 namespace AssetBundleHubEditor
 {
@@ -42,7 +43,7 @@ namespace AssetBundleHubEditor
         /// </summary>
         /// <param name="buildMap">key: assetBundle名 value: assetのプロジェクトの相対パス</param>
         /// <returns></returns>
-        public static void BuildAssetBundles(ABHubBuildParameters buildParameters, Dictionary<string, List<string>> buildMap)
+        public static void BuildAssetBundles(ABHubBuildParameters buildParameters, Dictionary<string, List<string>> buildMap, params IContextObject[] contextObjects)
         {
             foreach (var kvp in buildMap)
             {
@@ -61,7 +62,10 @@ namespace AssetBundleHubEditor
 
             var buildContent = new BundleBuildContent(builds);
             var tasks = CreateTaskList(buildParameters.ExtractBuiltinShader);
-            ReturnCode exitCode = ContentPipeline.BuildAssetBundles(buildParameters, buildContent, out IBundleBuildResults results, tasks);
+            var additionalContexts = new IContextObject[contextObjects.Length + 1];
+            Array.Copy(contextObjects, additionalContexts, contextObjects.Length);
+            additionalContexts[additionalContexts.Length - 1] = buildParameters as IABHubBuildParameters;
+            ReturnCode exitCode = ContentPipeline.BuildAssetBundles(buildParameters, buildContent, out IBundleBuildResults results, tasks, additionalContexts);
 
             Debug.Log($"BuildAssetBundles finished exitCode : {exitCode}");
         }

--- a/Editor/BuildPipeline.cs
+++ b/Editor/BuildPipeline.cs
@@ -42,7 +42,7 @@ namespace AssetBundleHubEditor
         /// </summary>
         /// <param name="buildMap">key: assetBundle名 value: assetのプロジェクトの相対パス</param>
         /// <returns></returns>
-        public static void BuildAssetBundles(ABHubBuildParameters buildParameters, Dictionary<string, List<string>> buildMap, bool extractBuiltinShader = true)
+        public static void BuildAssetBundles(ABHubBuildParameters buildParameters, Dictionary<string, List<string>> buildMap)
         {
             foreach (var kvp in buildMap)
             {
@@ -60,18 +60,7 @@ namespace AssetBundleHubEditor
             }
 
             var buildContent = new BundleBuildContent(builds);
-
-            IList<IBuildTask> tasks = null;
-            if (extractBuiltinShader)
-            {
-                tasks = DefaultBuildTasks.Create(DefaultBuildTasks.Preset.AssetBundleBuiltInShaderExtraction);
-            }
-            else
-            {
-                tasks = DefaultBuildTasks.Create(DefaultBuildTasks.Preset.AssetBundleCompatible);
-            }
-
-            tasks.Add(new CreateAssetBundleList(new MD5FileHashGenerator())); // ビルド結果からAssetBundleListを生成
+            var tasks = CreateTaskList(buildParameters.ExtractBuiltinShader);
             ReturnCode exitCode = ContentPipeline.BuildAssetBundles(buildParameters, buildContent, out IBundleBuildResults results, tasks);
 
             Debug.Log($"BuildAssetBundles finished exitCode : {exitCode}");
@@ -110,6 +99,22 @@ namespace AssetBundleHubEditor
                 return assetPathWithoutExtention;
             }
             return assetPathWithoutExtention.Replace(match.Value, "");
+        }
+
+        static IList<IBuildTask> CreateTaskList(bool extractBuiltinShader)
+        {
+            IList<IBuildTask> tasks = null;
+            if (extractBuiltinShader)
+            {
+                tasks = DefaultBuildTasks.Create(DefaultBuildTasks.Preset.AssetBundleBuiltInShaderExtraction);
+            }
+            else
+            {
+                tasks = DefaultBuildTasks.Create(DefaultBuildTasks.Preset.AssetBundleCompatible);
+            }
+
+            tasks.Add(new CreateAssetBundleList(new MD5FileHashGenerator())); // ビルド結果からAssetBundleListを生成
+            return tasks;
         }
     }
 }

--- a/Editor/BuildPipeline.cs
+++ b/Editor/BuildPipeline.cs
@@ -28,7 +28,7 @@ namespace AssetBundleHubEditor
         {
             var buildTarget = BuildTarget.StandaloneOSX;
             var buildTargetGroup = BuildTargetGroup.Standalone;
-            var buildParameters = new BundleBuildParameters(buildTarget, buildTargetGroup, outputFolder);
+            var buildParameters = new ABHubBuildParameters(buildTarget, buildTargetGroup, outputFolder);
             buildParameters.UseCache = false;
             buildParameters.BundleCompression = BuildCompression.LZ4;
             buildParameters.AppendHash = false; // ファイル名にHashを加えるのはAssetBundleの機能ではなくAssetBundleHub側で行う。
@@ -42,7 +42,7 @@ namespace AssetBundleHubEditor
         /// </summary>
         /// <param name="buildMap">key: assetBundle名 value: assetのプロジェクトの相対パス</param>
         /// <returns></returns>
-        public static void BuildAssetBundles(BundleBuildParameters buildParameters, Dictionary<string, List<string>> buildMap, bool extractBuiltinShader = true)
+        public static void BuildAssetBundles(ABHubBuildParameters buildParameters, Dictionary<string, List<string>> buildMap, bool extractBuiltinShader = true)
         {
             foreach (var kvp in buildMap)
             {

--- a/Editor/Interfaces.meta
+++ b/Editor/Interfaces.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fac18377ad923485584dd93b61e10c86
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Interfaces/IABHubBuildParameters.cs
+++ b/Editor/Interfaces/IABHubBuildParameters.cs
@@ -1,0 +1,27 @@
+using UnityEditor.Build.Pipeline.Interfaces;
+
+namespace AssetBundleHubEditor.Interfaces
+{
+    public enum EncryptType
+    {
+        None,
+        XOR
+    }
+
+    /// <summary>
+    /// ABHub専用のAssetBundleビルド時の設定パラメータ
+    /// </summary>
+    public interface IABHubBuildParameters : IContextObject
+    {
+        /// <summary>
+        /// AssetBundleListのファイル名
+        /// </summary>
+        string AssetBundleListName { get; set; }
+        EncryptType EncryptType { get; set; }
+
+        /// <summary>
+        /// EncryptTypeがNone以外の場合に使用
+        /// </summary>
+        string CryptKeyBase { get; set; }
+    }
+}

--- a/Editor/Interfaces/IABHubBuildParameters.cs.meta
+++ b/Editor/Interfaces/IABHubBuildParameters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57648d49643d34380bd57f785d7994b8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Shared.meta
+++ b/Editor/Shared.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c411ee183694e4c558fb83cf3fdd1e47
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Shared/ABHubBuildParameters.cs
+++ b/Editor/Shared/ABHubBuildParameters.cs
@@ -19,6 +19,7 @@ namespace AssetBundleHubEditor
         public string AssetBundleListName { get; set; } = "AssetBundleList.json";
         public EncryptType EncryptType { get; set; } = EncryptType.None;
         public string CryptKeyBase { get; set; }
+        public bool ExtractBuiltinShader { get; set; } = true;
 
         public ABHubBuildParameters(BuildTarget target, BuildTargetGroup group, string outputFolder)
             : base(target, group, outputFolder)

--- a/Editor/Shared/ABHubBuildParameters.cs
+++ b/Editor/Shared/ABHubBuildParameters.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using AssetBundleHubEditor.Interfaces;
+using UnityEditor;
+using UnityEditor.Build.Content;
+using UnityEditor.Build.Pipeline;
+using UnityEditor.Build.Pipeline.Interfaces;
+using UnityEditor.Build.Player;
+using UnityEngine;
+
+namespace AssetBundleHubEditor
+{
+    /// <summary>
+    /// AssetBundleのビルドに必要なパラメータを全てここにまとめる。
+    /// ここからContextObjectを分解する。
+    /// </summary>
+    public class ABHubBuildParameters : BundleBuildParameters, IABHubBuildParameters
+    {
+        public string AssetBundleListName { get; set; } = "AssetBundleList.json";
+        public EncryptType EncryptType { get; set; } = EncryptType.None;
+        public string CryptKeyBase { get; set; }
+
+        public ABHubBuildParameters(BuildTarget target, BuildTargetGroup group, string outputFolder)
+            : base(target, group, outputFolder)
+        {
+        }
+    }
+}

--- a/Editor/Shared/ABHubBuildParameters.cs.meta
+++ b/Editor/Shared/ABHubBuildParameters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8cbfb4ca4d86b45a5a56dbfc26b49949
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tasks/CreateAssetBundleList.cs
+++ b/Editor/Tasks/CreateAssetBundleList.cs
@@ -8,6 +8,7 @@ using UnityEditor.Build.Pipeline.Interfaces;
 using UnityEngine;
 using UnityEngine.Build.Pipeline;
 using AssetBundleHub;
+using AssetBundleHubEditor.Interfaces;
 
 namespace AssetBundleHubEditor.Tasks
 {
@@ -18,6 +19,9 @@ namespace AssetBundleHubEditor.Tasks
 #pragma warning disable 649
         [InjectContext(ContextUsage.In)]
         IBundleBuildResults results;
+
+        [InjectContext(ContextUsage.In)]
+        IABHubBuildParameters abHubBuildParameters;
 #pragma warning restore 649
 
         IFileHashGenerator fileHashGenerator;
@@ -32,7 +36,7 @@ namespace AssetBundleHubEditor.Tasks
             var bundleDetails = results.BundleInfos;
             var assetBundleList = BuildDetailsToAssetBundleList(bundleDetails);
             string dirPath = Path.GetDirectoryName(bundleDetails.Values.First().FileName);
-            string path = Path.Combine(dirPath, "AssetBundleList.json");
+            string path = Path.Combine(dirPath, abHubBuildParameters.AssetBundleListName);
             File.WriteAllText(path, JsonUtility.ToJson(assetBundleList));
             return ReturnCode.Success;
         }


### PR DESCRIPTION
## What is this PR?

issue
https://github.com/teach310/AssetBundleHub/issues/5

ABHubのビルド用のParameterをBuildTaskへと渡せるようにする

BundleBuildParametersとは完全に別のcontextとしてcontextObjectsに渡すことも可能。
ただし、BundleBuildParametersを継承したほうが引数減って使いやすいと判断


