### PR TITLE
add XOR暗号化 ビルド・ロード

### DIFF
--- a/Editor/BuildPipeline.cs
+++ b/Editor/BuildPipeline.cs
@@ -106,6 +106,12 @@ namespace AssetBundleHubEditor
             }
 
             tasks.Add(new CreateAssetBundleList()); // ビルド結果からAssetBundleListを生成
+
+            if (parameters.EncryptType != EncryptType.None)
+            {
+                tasks.Add(new EncryptAssetBundles());
+            }
+
             return tasks;
         }
     }

--- a/Editor/BuildPipeline.cs
+++ b/Editor/BuildPipeline.cs
@@ -25,19 +25,6 @@ namespace AssetBundleHubEditor
             Debug.Log($"export buildMap {exporter.ExportPath}");
         }
 
-        public static void BuildAssetBundlesStandaloneOSX(string outputFolder = "AssetBundles/StandaloneOSX", string loadPath = "Assets/AssetBundleResources")
-        {
-            var buildTarget = BuildTarget.StandaloneOSX;
-            var buildTargetGroup = BuildTargetGroup.Standalone;
-            var buildParameters = new ABHubBuildParameters(buildTarget, buildTargetGroup, outputFolder);
-            buildParameters.UseCache = false;
-            buildParameters.BundleCompression = BuildCompression.LZ4;
-            buildParameters.AppendHash = false; // ファイル名にHashを加えるのはAssetBundleの機能ではなくAssetBundleHub側で行う。
-
-            var buildMap = new BuildMapFactory().Create(loadPath, false);
-            BuildAssetBundles(buildParameters, buildMap);
-        }
-
         /// <summary>
         /// AssetBundleをビルドするメソッドのサンプル
         /// </summary>

--- a/Editor/BuildPipeline.cs
+++ b/Editor/BuildPipeline.cs
@@ -39,6 +39,7 @@ namespace AssetBundleHubEditor
                     throw new ArgumentException("AssetBundleName is null or empty");
                 }
             }
+            buildParameters.SetDefaultParamsIfNeeded();
 
             var builds = CreateAssetBundleBuilds(buildMap);
             if (builds.Length == 0)
@@ -48,7 +49,7 @@ namespace AssetBundleHubEditor
             }
 
             var buildContent = new BundleBuildContent(builds);
-            var tasks = CreateTaskList(buildParameters.ExtractBuiltinShader);
+            var tasks = CreateTaskList(buildParameters);
             var additionalContexts = new IContextObject[contextObjects.Length + 1];
             Array.Copy(contextObjects, additionalContexts, contextObjects.Length);
             additionalContexts[additionalContexts.Length - 1] = buildParameters as IABHubBuildParameters;
@@ -92,10 +93,10 @@ namespace AssetBundleHubEditor
             return assetPathWithoutExtention.Replace(match.Value, "");
         }
 
-        static IList<IBuildTask> CreateTaskList(bool extractBuiltinShader)
+        static IList<IBuildTask> CreateTaskList(ABHubBuildParameters parameters)
         {
             IList<IBuildTask> tasks = null;
-            if (extractBuiltinShader)
+            if (parameters.ExtractBuiltinShader)
             {
                 tasks = DefaultBuildTasks.Create(DefaultBuildTasks.Preset.AssetBundleBuiltInShaderExtraction);
             }
@@ -104,7 +105,7 @@ namespace AssetBundleHubEditor
                 tasks = DefaultBuildTasks.Create(DefaultBuildTasks.Preset.AssetBundleCompatible);
             }
 
-            tasks.Add(new CreateAssetBundleList(new MD5FileHashGenerator())); // ビルド結果からAssetBundleListを生成
+            tasks.Add(new CreateAssetBundleList()); // ビルド結果からAssetBundleListを生成
             return tasks;
         }
     }

--- a/Editor/Interfaces/IABHubBuildParameters.cs
+++ b/Editor/Interfaces/IABHubBuildParameters.cs
@@ -1,13 +1,9 @@
+using AssetBundleHub;
+using AssetBundleHubEditor;
 using UnityEditor.Build.Pipeline.Interfaces;
 
 namespace AssetBundleHubEditor.Interfaces
 {
-    public enum EncryptType
-    {
-        None,
-        XOR
-    }
-
     /// <summary>
     /// ABHub専用のAssetBundleビルド時の設定パラメータ
     /// </summary>

--- a/Editor/Interfaces/IABHubBuildParameters.cs
+++ b/Editor/Interfaces/IABHubBuildParameters.cs
@@ -19,5 +19,7 @@ namespace AssetBundleHubEditor.Interfaces
         /// EncryptTypeがNone以外の場合に使用
         /// </summary>
         string CryptKeyBase { get; set; }
+
+        IFileHashGenerator FileHashGenerator { get; set; }
     }
 }

--- a/Editor/Shared/ABHubBuildParameters.cs
+++ b/Editor/Shared/ABHubBuildParameters.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using AssetBundleHub;
 using AssetBundleHubEditor.Interfaces;
 using UnityEditor;
 using UnityEditor.Build.Content;
@@ -20,10 +21,20 @@ namespace AssetBundleHubEditor
         public EncryptType EncryptType { get; set; } = EncryptType.None;
         public string CryptKeyBase { get; set; }
         public bool ExtractBuiltinShader { get; set; } = true;
+        public IFileHashGenerator FileHashGenerator { get; set; }
 
         public ABHubBuildParameters(BuildTarget target, BuildTargetGroup group, string outputFolder)
             : base(target, group, outputFolder)
         {
+            AppendHash = false;
+        }
+
+        public void SetDefaultParamsIfNeeded()
+        {
+            if (FileHashGenerator == null)
+            {
+                FileHashGenerator = new MD5FileHashGenerator();
+            }
         }
     }
 }

--- a/Editor/Shared/EncryptType.cs
+++ b/Editor/Shared/EncryptType.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AssetBundleHubEditor
+{
+    public enum EncryptType
+    {
+        None,
+        XOR
+    }
+}

--- a/Editor/Shared/EncryptType.cs.meta
+++ b/Editor/Shared/EncryptType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a79a795cf3b55439db2ed057fb6311ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tasks/CreateAssetBundleList.cs
+++ b/Editor/Tasks/CreateAssetBundleList.cs
@@ -33,8 +33,7 @@ namespace AssetBundleHubEditor.Tasks
 
         public ReturnCode Run()
         {
-            var bundleDetails = results.BundleInfos;
-            var assetBundleList = BuildDetailsToAssetBundleList(bundleDetails);
+            var assetBundleList = BuildDetailsToAssetBundleList(results.BundleInfos);
             File.WriteAllText(parameters.GetOutputFilePathForIdentifier(parameters.AssetBundleListName), JsonUtility.ToJson(assetBundleList));
             return ReturnCode.Success;
         }
@@ -42,13 +41,13 @@ namespace AssetBundleHubEditor.Tasks
         /// <summary>
         /// AssetBundleListを作成
         /// </summary>
-        /// <param name="bundleDetails">keyはassetBundleのファイル名、value.FileNameは相対パス</param>
+        /// <param name="bundleInfos">keyはassetBundleのファイル名、value.FileNameは相対パス</param>
         /// <returns></returns>
-        AssetBundleList BuildDetailsToAssetBundleList(Dictionary<string, BundleDetails> bundleDetails)
+        AssetBundleList BuildDetailsToAssetBundleList(Dictionary<string, BundleDetails> bundleInfos)
         {
             var infoList = new List<AssetBundleInfo>();
             AssetBundle.UnloadAllAssetBundles(true); // すでにロード済みだとバグるので
-            foreach (var kvp in bundleDetails)
+            foreach (var kvp in bundleInfos)
             {
                 string assetBundleName = kvp.Key;
                 var details = kvp.Value;

--- a/Editor/Tasks/CreateAssetBundleList.cs
+++ b/Editor/Tasks/CreateAssetBundleList.cs
@@ -24,13 +24,6 @@ namespace AssetBundleHubEditor.Tasks
         IABHubBuildParameters parameters;
 #pragma warning restore 649
 
-        IFileHashGenerator fileHashGenerator;
-
-        public CreateAssetBundleList(IFileHashGenerator fileHashGenerator)
-        {
-            this.fileHashGenerator = fileHashGenerator;
-        }
-
         public ReturnCode Run()
         {
             var assetBundleList = BuildDetailsToAssetBundleList(results.BundleInfos);
@@ -53,7 +46,7 @@ namespace AssetBundleHubEditor.Tasks
                 var details = kvp.Value;
                 string assetBundleRelativePath = details.FileName;
                 var dep = details.Dependencies.ToList();
-                string hash = fileHashGenerator.ComputeHash(assetBundleRelativePath);
+                string hash = parameters.FileHashGenerator.ComputeHash(assetBundleRelativePath);
                 string fileHash = hash; // 破損チェック用
 
                 // ファイルサイズ取得

--- a/Editor/Tasks/EncryptAssetBundles.cs
+++ b/Editor/Tasks/EncryptAssetBundles.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor.Build.Pipeline;
+using UnityEditor.Build.Pipeline.Injector;
+using UnityEditor.Build.Pipeline.Interfaces;
+using UnityEngine;
+using AssetBundleHub;
+using AssetBundleHubEditor.Interfaces;
+using System.Text;
+
+namespace AssetBundleHubEditor.Tasks
+{
+    public class EncryptAssetBundles : IBuildTask
+    {
+        public int Version => 1;
+
+#pragma warning disable 649
+        [InjectContext(ContextUsage.In)]
+        IBundleBuildResults results;
+
+        [InjectContext(ContextUsage.In)]
+        IABHubBuildParameters parameters;
+#pragma warning restore 649
+
+        Dictionary<string, string> abNameToTempMap = new Dictionary<string, string>();
+        Dictionary<string, string> abNameToOutputMap = new Dictionary<string, string>();
+        Dictionary<string, string> tempToOutputMap = new Dictionary<string, string>(); // 最後にtempから移動する用
+
+        public ReturnCode Run()
+        {
+            var assetBundleListPath = parameters.GetOutputFilePathForIdentifier(parameters.AssetBundleListName);
+            var assetBundleListTempPath = string.Format("{0}/{1}", parameters.TempOutputFolder, parameters.AssetBundleListName);
+            var assetBundleList = AssetBundleList.LoadFromFile(assetBundleListPath);
+
+            SetAssetBundlePathMap(assetBundleList);
+            tempToOutputMap[assetBundleListTempPath] = assetBundleListPath;
+
+            var cryptKey = Encoding.UTF8.GetBytes(parameters.CryptKeyBase); // TODO: keyをそのまま使わず、変換したい
+            EncryptBundles(cryptKey);
+            UpdateAssetBundleList(assetBundleList);
+            EncryptAssetBundleList(assetBundleList, assetBundleListTempPath, cryptKey);
+
+            MoveTempToOutput();
+
+            return ReturnCode.Success;
+        }
+
+        // 何度も呼ばないために、使うパスを取得してキャッシュ
+        void SetAssetBundlePathMap(AssetBundleList assetBundleList)
+        {
+            foreach (var kvp in assetBundleList.Infos)
+            {
+                string abName = kvp.Value.Name;
+                string tempPath = string.Format("{0}/{1}", parameters.TempOutputFolder, abName);
+                string outputPath = parameters.GetOutputFilePathForIdentifier(abName);
+                abNameToTempMap[abName] = tempPath;
+                abNameToOutputMap[abName] = outputPath;
+                tempToOutputMap[tempPath] = outputPath;
+            }
+        }
+
+        // NOTE: 時間がかかる場合には非同期にして並列で走らせることを検討
+        void EncryptBundles(byte[] keyBytes)
+        {
+            foreach (var kvp in abNameToTempMap)
+            {
+                string srcPath = abNameToOutputMap[kvp.Key];
+                EncryptFile(srcPath, kvp.Value, keyBytes);
+            }
+        }
+
+        void EncryptFile(string srcPath, string destPath, byte[] keyBytes)
+        {
+            using var fileReader = new FileStream(srcPath, FileMode.Open);
+            using var fileWriter = new FileStream(destPath, FileMode.Create);
+            using var cs = new XORCryptStream(fileWriter, keyBytes);
+            fileReader.CopyTo(cs);
+        }
+
+        /// <summary>
+        /// AssetBundleを暗号化するとFileHashが変わるので更新する必要がある
+        /// </summary>
+        void UpdateAssetBundleList(AssetBundleList assetBundleList)
+        {
+            foreach (var kvp in assetBundleList.Infos)
+            {
+                var abInfo = kvp.Value;
+                var tempABPath = abNameToTempMap[abInfo.Name];
+                abInfo.SetFileHash(parameters.FileHashGenerator.ComputeHash(tempABPath));
+            }
+        }
+
+        void EncryptAssetBundleList(AssetBundleList assetBundleList, string destPath, byte[] keyBytes)
+        {
+            var assetBundleListBytes = Encoding.UTF8.GetBytes(JsonUtility.ToJson(assetBundleList));
+            WriteFileWithEncryption(assetBundleListBytes, destPath, keyBytes);
+        }
+
+        void WriteFileWithEncryption(byte[] content, string destPath, byte[] keyBytes)
+        {
+            using var ms = new MemoryStream(content);
+            using var fileWriter = new FileStream(destPath, FileMode.Create);
+            using var cs = new XORCryptStream(fileWriter, keyBytes);
+            ms.CopyTo(cs);
+        }
+
+        void MoveTempToOutput()
+        {
+            foreach (var kvp in tempToOutputMap)
+            {
+                File.Delete(kvp.Value);
+                File.Move(kvp.Key, kvp.Value);
+            }
+        }
+    }
+}

--- a/Editor/Tasks/EncryptAssetBundles.cs.meta
+++ b/Editor/Tasks/EncryptAssetBundles.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84dbe4a0bc4814b7184cf2966389ecd0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/AssetBundleList.cs
+++ b/Runtime/AssetBundleList.cs
@@ -98,5 +98,12 @@ namespace AssetBundleHub
             this.directDependencies = directDependencies;
             this.assetNames = assetNames;
         }
+
+        // 暗号化するときにFileHashだけは更新する
+        // どこでセットするか検索しやすくするためにプロパティーではなく別メソッドにしておく
+        public void SetFileHash(string fileHash)
+        {
+            this.fileHash = fileHash;
+        }
     }
 }

--- a/Runtime/IAssetBundleListLoader.cs
+++ b/Runtime/IAssetBundleListLoader.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using UnityEngine;
 
 namespace AssetBundleHub
@@ -15,5 +17,27 @@ namespace AssetBundleHub
         public AssetBundleList Load(string path) => AssetBundleList.LoadFromFile(path);
 
         public static AssetBundleListLoader New() => new AssetBundleListLoader();
+    }
+
+    public class XORAssetBundleListLoader : IAssetBundleListLoader
+    {
+        byte[] keyBytes;
+
+        public XORAssetBundleListLoader(byte[] keyBytes)
+        {
+            this.keyBytes = keyBytes;
+        }
+
+        public AssetBundleList Load(string path)
+        {
+            AssetBundleList assetBundleList = null;
+            using (var fs = new FileStream(path, FileMode.Open))
+            using (var cs = new XORCryptStream(fs, keyBytes))
+            {
+                var sr = new StreamReader(cs, Encoding.UTF8);
+                assetBundleList = JsonUtility.FromJson<AssetBundleList>(sr.ReadToEnd());
+            }
+            return assetBundleList;
+        }
     }
 }

--- a/Runtime/IAssetBundleReader.cs
+++ b/Runtime/IAssetBundleReader.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -27,6 +28,27 @@ namespace AssetBundleHub
         public async UniTask<AssetBundle> LoadFromFileAsync(string path, CancellationToken cancellationToken = default)
         {
             return await AssetBundle.LoadFromFileAsync(path, 0).ToUniTask(cancellationToken: cancellationToken);
+        }
+    }
+
+    public class XORAssetBundleReader : IAssetBundleReader
+    {
+        byte[] keyBytes;
+
+        public XORAssetBundleReader(byte[] keyBytes)
+        {
+            this.keyBytes = keyBytes;
+        }
+
+        public async UniTask<AssetBundle> LoadFromFileAsync(string path, CancellationToken cancellationToken = default)
+        {
+            AssetBundle assetBundle = null;
+            using (var fs = new FileStream(path, FileMode.Open))
+            using (var cs = new XORCryptStream(fs, keyBytes))
+            {
+                assetBundle = await AssetBundle.LoadFromStreamAsync(cs, 0).ToUniTask(cancellationToken: cancellationToken);
+            }
+            return assetBundle;
         }
     }
 }

--- a/Runtime/XORCryptStream.cs
+++ b/Runtime/XORCryptStream.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+
+namespace AssetBundleHub
+{
+    public class XORCryptStream : Stream
+    {
+        Stream baseStream;
+        byte[] key;
+
+        public XORCryptStream(Stream baseStream, byte[] key)
+        {
+            this.baseStream = baseStream;
+            this.key = key;
+        }
+
+        public override bool CanRead => baseStream.CanRead;
+
+        public override bool CanSeek => baseStream.CanSeek;
+
+        public override bool CanWrite => baseStream.CanWrite;
+
+        public override long Length => baseStream.Length;
+
+        public override long Position { get { return baseStream.Position; } set { baseStream.Position = value; } }
+
+        public override void Flush() => baseStream.Flush();
+
+        public override long Seek(long offset, SeekOrigin origin) => baseStream.Seek(offset, origin);
+
+        public override void SetLength(long value) => baseStream.SetLength(value);
+
+        /// <summary>
+        /// 復号化しつつ読む
+        /// </summary>
+        /// <param name="buffer">結果を格納するbuffer</param>
+        /// <param name="offset">bufferのoffset番目から格納</param>
+        /// <param name="count">何byte読み込むか</param>
+        /// <returns>読み取ったbyte数を返す</returns>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var startPosition = Position;
+            int readCount = baseStream.Read(buffer, offset, count);
+
+            int keyIndex = (int)(startPosition % key.Length);
+            for (int i = 0; i < readCount; i++)
+            {
+                int bufferIndex = i + offset;
+                if (keyIndex == key.Length)
+                {
+                    keyIndex = 0;
+                }
+                buffer[bufferIndex] ^= key[keyIndex]; // xor
+                keyIndex++;
+            }
+            return readCount;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (buffer.Length < offset + count)
+            {
+                throw new ArgumentException("offset + count is larger than buffer.Length");
+            }
+
+            byte[] writeBuffer = new byte[count];
+            var startPosition = Position;
+            int keyIndex = (int)(startPosition % key.Length);
+            for (int i = 0; i < count; i++)
+            {
+                int bufferIndex = i + offset;
+                if (keyIndex == key.Length)
+                {
+                    keyIndex = 0;
+                }
+
+                writeBuffer[i] = buffer[bufferIndex];
+                writeBuffer[i] ^= key[keyIndex];
+                keyIndex++;
+            }
+            baseStream.Write(writeBuffer, 0, count);
+        }
+    }
+}

--- a/Runtime/XORCryptStream.cs.meta
+++ b/Runtime/XORCryptStream.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae9b1ab0b6d5e4b8b9eb3f75382fd226
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/XORCryptStreamTest.cs
+++ b/Tests/Runtime/XORCryptStreamTest.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using AssetBundleHub;
+using AssetBundleHub.Tasks;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace AssetBundleHubTests
+{
+    public class XORCryptStreamTest
+    {
+        [Test]
+        public void Read_XORをかけつつ読み込める()
+        {
+            string key = "1234abcd";
+            byte[] keyBytes = Encoding.UTF8.GetBytes(key);
+            byte[] encryptedHelloWorld = new byte[] { 89, 87, 95, 88, 14, 21, 12, 22, 93, 86 };
+
+            byte[] buffer1 = new byte[3];
+            byte[] buffer2 = new byte[4];
+
+            using (var ms = new MemoryStream(encryptedHelloWorld, false))
+            using (var cs = new XORCryptStream(ms, keyBytes))
+            {
+                int readCount1 = cs.Read(buffer1, 1, 2);
+                Assert.AreEqual(2, readCount1);
+
+                int readCount2 = cs.Read(buffer2, 2, 1);
+                Assert.AreEqual(1, readCount2);
+            }
+
+            Assert.AreEqual(0, Convert.ToInt32(buffer1[0]), "offset指定で書き込まない");
+            Assert.AreEqual(104, Convert.ToInt32(buffer1[1]), "h");
+            Assert.AreEqual(101, Convert.ToInt32(buffer1[2]), "e");
+
+            Assert.AreEqual(0, Convert.ToInt32(buffer2[0]), "offset指定で書き込まない");
+            Assert.AreEqual(0, Convert.ToInt32(buffer2[1]), "offset指定で書き込まない");
+            Assert.AreEqual(108, Convert.ToInt32(buffer2[2]), "l");
+            Assert.AreEqual(0, Convert.ToInt32(buffer2[3]), "書き込み範囲外");
+        }
+
+        [Test]
+        public void Write_XORをかけつつ書き込める()
+        {
+            string key = "1234abcd";
+            byte[] keyBytes = Encoding.UTF8.GetBytes(key);
+
+            byte[] encryptedHello = new byte[] { 89, 87, 95, 88, 14 };
+            byte[] encryptedWorld = new byte[] { 0, 0, 21, 12, 22, 93, 86 }; // 最初の2つはoffsetの確認用
+            byte[] buffer = new byte[10];
+
+            using (var ms = new MemoryStream())
+            using (var cs = new XORCryptStream(ms, keyBytes))
+            {
+                cs.Write(encryptedHello, 0, 5);
+                cs.Write(encryptedWorld, 2, 5); // offset分ずらす
+
+                Assert.AreEqual(10, ms.Length);
+                ms.Seek(0L, SeekOrigin.Begin);
+                ms.Read(buffer, 0, buffer.Length);
+            }
+            Assert.AreEqual("helloworld", Encoding.UTF8.GetString(buffer));
+        }
+    }
+}

--- a/Tests/Runtime/XORCryptStreamTest.cs.meta
+++ b/Tests/Runtime/XORCryptStreamTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97df184ce2b51481089eeeba9a7ed945
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 背景
AssetBundleおよびAssetBundleListは暗号化しておかないと中身が全て見ることが可能。
Assetの流出を避けるために暗号化が必要になる。

## このPRについて
高速に復号化を行うために、XORを用いた暗号化を実装。
簡単に中身を見れないようにするためのもののため、強度は低い。

暗号化のキーと復号化のキーは同一のものを用いる。(XORの特徴)

## 使用方法

ビルド

```.cs
buildParameters.EncryptType = EncryptType.XOR;
buildParameters.CryptKeyBase = "暗号化用のキー";
```

ロード(ABHub.Initializeの前に呼ぶ)
```.cs
byte[] keyBytes = Encoding.UTF8.GetBytes("暗号化用のキー");
if (useEncrypted)
{
     var serviceLocator = AssetBundleHub.ServiceLocator.Instance;
    serviceLocator.Register<IAssetBundleListLoader>(new XORAssetBundleListLoader(keyBytes));
    serviceLocator.Register<IAssetBundleReader>(new XORAssetBundleReader(keyBytes));
}
```

