### PR TITLE
fix: Stream Dispose Timing

### DIFF
--- a/Runtime/AssetBundleLocalRepository.cs
+++ b/Runtime/AssetBundleLocalRepository.cs
@@ -326,7 +326,7 @@ namespace AssetBundleHub
             {
                 DecrementRefCountRecursive(assetBundleName, assetBundleName, onNoRef: (key, abRef) =>
                 {
-                    abRef.AssetBundle.Unload(true); // NOTE: 読み込み済みAssetは強制解放。参照カウント0ならAssetは参照されていないと判断する。
+                    abRef.Unload(true); // NOTE: 読み込み済みAssetは強制解放。参照カウント0ならAssetは参照されていないと判断する。
                     assetBundleRefs.Remove(key);
                 });
             }
@@ -340,7 +340,7 @@ namespace AssetBundleHub
         {
             foreach (var kvp in assetBundleRefs)
             {
-                kvp.Value.AssetBundle.Unload(true);
+                kvp.Value.Unload(true);
             }
             assetBundleRefs.Clear();
         }

--- a/Runtime/AssetBundleLocalRepository.cs
+++ b/Runtime/AssetBundleLocalRepository.cs
@@ -227,12 +227,13 @@ namespace AssetBundleHub
                     await LoadAsync(d); // 参照カウントを中途半端に終わらせたくないためここではキャンセルさせない
                 }
 
-                assetBundle = await assetBundleReader.LoadFromFileAsync(GetAssetBundlePath(assetBundleName));
+                var assetBundleRef = await assetBundleReader.LoadFromFileAsync(GetAssetBundlePath(assetBundleName));
+                assetBundle = assetBundleRef.AssetBundle;
                 if (assetBundle == null)
                 {
                     throw new Exception($"loaded assetbundle is null {assetBundleName}");
                 }
-                assetBundleRefs.Add(assetBundleName, new AssetBundleRef(assetBundle));
+                assetBundleRefs.Add(assetBundleName, assetBundleRef);
             }
             finally
             {

--- a/Runtime/AssetBundleRef.cs
+++ b/Runtime/AssetBundleRef.cs
@@ -14,8 +14,9 @@ namespace AssetBundleHub
     {
         public AssetBundle AssetBundle { get; private set; }
         public int Count { get; private set; }
+        List<IDisposable> disposables; // Streamの解放タイミングを制御するために保持
 
-        public AssetBundleRef(AssetBundle assetBundle)
+        public AssetBundleRef(AssetBundle assetBundle, List<IDisposable> disposables = null)
         {
             if (assetBundle == null)
             {
@@ -24,6 +25,7 @@ namespace AssetBundleHub
 
             AssetBundle = assetBundle;
             Count = 1;
+            this.disposables = disposables;
         }
 
         internal void IncrementRefCount()
@@ -34,6 +36,18 @@ namespace AssetBundleHub
         internal void DecrementRefCount()
         {
             Count--;
+        }
+
+        public void Unload(bool unloadAllLoadedObjects)
+        {
+            AssetBundle.Unload(unloadAllLoadedObjects);
+            if (disposables != null)
+            {
+                foreach (var disposable in disposables)
+                {
+                    disposable.Dispose();
+                }
+            }
         }
     }
 }

--- a/Runtime/IAssetBundleReader.cs
+++ b/Runtime/IAssetBundleReader.cs
@@ -11,7 +11,7 @@ namespace AssetBundleHub
     /// </summary>
     public interface IAssetBundleReader
     {
-        UniTask<AssetBundle> LoadFromFileAsync(string path, CancellationToken cancellationToken = default);
+        UniTask<AssetBundleRef> LoadFromFileAsync(string path, CancellationToken cancellationToken = default);
     }
 
     public static class DefaultAssetBundleReader
@@ -25,9 +25,10 @@ namespace AssetBundleHub
     /// </summary>
     public class AssetBundleReader : IAssetBundleReader
     {
-        public async UniTask<AssetBundle> LoadFromFileAsync(string path, CancellationToken cancellationToken = default)
+        public async UniTask<AssetBundleRef> LoadFromFileAsync(string path, CancellationToken cancellationToken = default)
         {
-            return await AssetBundle.LoadFromFileAsync(path, 0).ToUniTask(cancellationToken: cancellationToken);
+            var assetBundle = await AssetBundle.LoadFromFileAsync(path, 0).ToUniTask(cancellationToken: cancellationToken);
+            return new AssetBundleRef(assetBundle);
         }
     }
 
@@ -40,7 +41,7 @@ namespace AssetBundleHub
             this.keyBytes = keyBytes;
         }
 
-        public async UniTask<AssetBundle> LoadFromFileAsync(string path, CancellationToken cancellationToken = default)
+        public async UniTask<AssetBundleRef> LoadFromFileAsync(string path, CancellationToken cancellationToken = default)
         {
             AssetBundle assetBundle = null;
             using (var fs = new FileStream(path, FileMode.Open))
@@ -48,7 +49,7 @@ namespace AssetBundleHub
             {
                 assetBundle = await AssetBundle.LoadFromStreamAsync(cs, 0).ToUniTask(cancellationToken: cancellationToken);
             }
-            return assetBundle;
+            return new AssetBundleRef(assetBundle);
         }
     }
 }


### PR DESCRIPTION
## 本PRについて

AssetBundleのLoadに使用したStreamのDisposeのタイミングをAssetBundle.Unloadの後にする

## 背景
AssetBundleをLoadしてすぐにStreamをUnloadしたところ、別のタイミングでDisposeされたstreamへアクセスされてエラーが発生してしまったのでそれの対応


## ドキュメント

> Do not dispose the Stream object while loading the AssetBundle or any assets from the bundle. Its lifetime should be longer than the AssetBundle. This means you dispose the Stream object after calling [AssetBundle.Unload](https://docs.unity3d.com/ja/2021.3/ScriptReference/AssetBundle.Unload.html).

https://docs.unity3d.com/ja/2021.3/ScriptReference/AssetBundle.LoadFromStreamAsync.html